### PR TITLE
Visualize unwilliness to fight

### DIFF
--- a/EventDefinitions.h
+++ b/EventDefinitions.h
@@ -1,7 +1,12 @@
 //Copyright (c) Piet Wauters 2022 <piet.wauters@gmail.com>
 #ifndef EVENTDEFINITIONS_H
 #define EVENTDEFINITIONS_H
-
+// Typedefinition to access individual bytes of a 32 bit unsigned
+union mix_t
+{
+    std::uint32_t theDWord;
+    std::uint8_t theBytes[4];
+};
 
 // An event is represented as a 32 bit unsigned integer
 // The most significant 8 bits represent the Main Type

--- a/FPA422Handler.h
+++ b/FPA422Handler.h
@@ -14,12 +14,6 @@
 
 #define MAX_MESSAGE_TYPE 9
 
-union mix_t
-{
-    std::uint32_t theDWord;
-    std::uint8_t theBytes[4];
-};
-
 class FPA422Handler : public Observer<FencingStateMachine>
 {
     public:

--- a/FencingStateMachine.cpp
+++ b/FencingStateMachine.cpp
@@ -353,6 +353,7 @@ void FencingStateMachine::ResetAll()
      StateChanged(EVENT_YELLOW_CARD_RIGHT);
      StateChanged(EVENT_RED_CARD_LEFT);
      StateChanged(EVENT_YELLOW_CARD_LEFT);
+     StateChanged(EVENT_P_CARD);
 
      if(m_TheSensor)
      {

--- a/TimeScoreDisplay.cpp
+++ b/TimeScoreDisplay.cpp
@@ -13,12 +13,6 @@ static const int spiClk = 1000000; // 1 MHz
 SPIClass hspi(HSPI);
 MD_MAX72XX mx = MD_MAX72XX(HARDWARE_TYPE, hspi, CS_PIN, MAX_DEVICES);
 
-union mix_t
-{
-    std::uint32_t theDWord;
-    std::uint8_t theBytes[4];
-};
-
 
 uint8_t numbers[][9]= {{5,62,81,73,69,62,0,0,0},
 {3,66,127,64,0,0,0,0,0},

--- a/UDPIOHandler.cpp
+++ b/UDPIOHandler.cpp
@@ -6,11 +6,6 @@
 
 AsyncUDP Commandudp;
 
-union mix_t
-{
-    std::uint32_t theDWord;
-    std::uint8_t theBytes[4];
-};
 
 static bool bWifiConnected = false;
 static bool bUDPConnected = false;

--- a/WS2812BLedStrip.cpp
+++ b/WS2812BLedStrip.cpp
@@ -1,11 +1,6 @@
 //Copyright (c) Piet Wauters 2022 <piet.wauters@gmail.com>
 #include "WS2812BLedStrip.h"
 
-union mix_t
-{
-    std::uint32_t theDWord;
-    std::uint8_t theBytes[4];
-};
 
 char Cross[] = {1,1,0,0,0,0,1,1,
                 1,1,1,0,0,1,1,1,
@@ -307,6 +302,63 @@ void WS2812B_LedStrip:: update (FencingStateMachine *subject, uint32_t eventtype
     SetLedStatus(0xff);
     break;
 
+
+    case EVENT_P_CARD:
+        //StateChanged(EVENT_P_CARD |  m_PCardLeft | m_PCardRight << 8);
+        mix_t PCardInfo;
+        PCardInfo.theDWord = event_data;
+        switch (PCardInfo.theBytes[0])
+        {
+          case 0:
+          m_YellowPCardLeft = false;
+          m_RedPCardLeft = 0;
+          break;
+
+          case 1:
+          m_YellowPCardLeft = true;
+          m_RedPCardLeft = 0;
+          break;
+
+          case 2:
+          m_YellowPCardLeft = true;
+          m_RedPCardLeft = 1;
+          break;
+
+          case 3:
+          m_YellowPCardLeft = true;
+          m_RedPCardLeft = 2;
+          break;
+
+        }
+
+        switch (PCardInfo.theBytes[1])
+        {
+          case 0:
+          m_YellowPCardRight = false;
+          m_RedPCardRight = 0;
+          break;
+
+          case 1:
+          m_YellowPCardRight = true;
+          m_RedPCardRight = 0;
+          break;
+
+          case 2:
+          m_YellowPCardRight = true;
+          m_RedPCardRight = 1;
+          break;
+
+          case 3:
+          m_YellowPCardRight = true;
+          m_RedPCardRight = 2;
+          break;
+
+        }
+
+
+        SetLedStatus(0xff);
+    break;
+
   }
 
 }
@@ -353,6 +405,8 @@ void WS2812B_LedStrip::SetLedStatus(unsigned char val)
           setYellowCardLeft(m_YellowCardLeft);
           setRedCardLeft(m_RedCardLeft);
           setUWFTimeLeft(m_UW2Ftens);
+          setYellowPCardLeft(m_YellowPCardLeft);
+          setRedPCardLeft(m_RedPCardLeft);
       }
     }
 
@@ -368,6 +422,8 @@ void WS2812B_LedStrip::SetLedStatus(unsigned char val)
         setYellowCardRight(m_YellowCardRight);
         setRedCardRight(m_RedCardRight);
         setUWFTimeRight(m_UW2Ftens);
+        setYellowPCardRight(m_YellowPCardRight);
+        setRedPCardRight(m_RedPCardRight);
       }
     }
     setBuzz(m_LedStatus & MASK_BUZZ);
@@ -497,4 +553,73 @@ void WS2812B_LedStrip::setUWFTimeLeft(uint8_t tens)
 void WS2812B_LedStrip::setUWFTimeRight(uint8_t tens)
 {
   setUWFTime(tens,120);
+}
+
+void WS2812B_LedStrip::setYellowPCardRight(bool Value)
+{
+  uint32_t theFillColor = m_Off;
+    if(Value)
+    {
+        theFillColor = m_Yellow;
+    }
+    m_pixels->setPixelColor(121,theFillColor);
+    m_pixels->setPixelColor(121 - 8,theFillColor);
+
+}
+
+void WS2812B_LedStrip::setYellowPCardLeft(bool Value)
+{
+  uint32_t theFillColor = m_Off;
+    if(Value)
+    {
+        theFillColor = m_Yellow;
+    }
+    m_pixels->setPixelColor(62,theFillColor);
+    m_pixels->setPixelColor(62 - 8,theFillColor);
+
+}
+
+void WS2812B_LedStrip::setRedPCardRight(uint8_t nr)
+{
+  uint32_t theFillColor1 = m_Off;
+  uint32_t theFillColor2 = m_Off;
+
+    if(nr == 2)
+    {
+        theFillColor1 = m_Red;
+        theFillColor2 = m_Red;
+    }
+    if(nr == 1)
+    {
+        theFillColor1 = m_Red;
+    }
+
+// Red2
+    m_pixels->setPixelColor(122 + 1,theFillColor2);
+    m_pixels->setPixelColor(122 + 1 - 8,theFillColor2);
+// Red1
+    m_pixels->setPixelColor(122 ,theFillColor1);
+    m_pixels->setPixelColor(122 - 8,theFillColor1);
+
+}
+
+void WS2812B_LedStrip::setRedPCardLeft(uint8_t nr)
+{
+  uint32_t theFillColor1 = m_Off;
+  uint32_t theFillColor2 = m_Off;
+
+    if(nr == 2)
+    {
+        theFillColor1 = m_Red;
+        theFillColor2 = m_Red;
+    }
+    if(nr == 1)
+    {
+        theFillColor1 = m_Red;
+    }
+    m_pixels->setPixelColor(61 ,theFillColor1);
+    m_pixels->setPixelColor(61 - 8,theFillColor1);
+    m_pixels->setPixelColor(61 - 1,theFillColor2);
+    m_pixels->setPixelColor(61 - 1  - 8,theFillColor2);
+
 }

--- a/WS2812BLedStrip.h
+++ b/WS2812BLedStrip.h
@@ -71,10 +71,20 @@ class WS2812B_LedStrip : public Observer<FencingStateMachine>
         void setYellowCardRight(bool Value);
         void setRedCardLeft(bool Value);
         void setRedCardRight(bool Value);
+        void setYellowPCardLeft(bool Value);
+        void setYellowPCardRight(bool Value);
+        void setRedPCardLeft(bool Value);
+        void setRedPCardRight(bool Value);
+
+        void setUWFTimeLeft(uint8_t tens);
+        void setUWFTimeRight(uint8_t tens);
+
 
     protected:
 
     private:
+
+        void setUWFTime(uint8_t tens, uint8_t bottom);
         unsigned char m_LedStatus; //!< Member variable "m_LedStatus"
         Adafruit_NeoPixel *m_pixels;
         uint8_t m_Brightness = 30;
@@ -84,6 +94,7 @@ class WS2812B_LedStrip : public Observer<FencingStateMachine>
         uint32_t   m_White;
         uint32_t   m_Orange;
         uint32_t   m_Yellow;
+        uint32_t   m_Blue;
         uint32_t   m_Off;
         uint32_t m_LastEvent = 0;
         bool m_PrioLeft = false;
@@ -92,6 +103,7 @@ class WS2812B_LedStrip : public Observer<FencingStateMachine>
         bool m_YellowCardRight = false;
         bool m_RedCardLeft = false;
         bool m_RedCardRight = false;
+        uint8_t m_UW2Ftens = 0;
         QueueHandle_t queue = NULL;
         uint32_t m_NextTimeToTogglePrioLights;
         bool m_Animating = false;

--- a/WS2812BLedStrip.h
+++ b/WS2812BLedStrip.h
@@ -73,8 +73,8 @@ class WS2812B_LedStrip : public Observer<FencingStateMachine>
         void setRedCardRight(bool Value);
         void setYellowPCardLeft(bool Value);
         void setYellowPCardRight(bool Value);
-        void setRedPCardLeft(bool Value);
-        void setRedPCardRight(bool Value);
+        void setRedPCardLeft(uint8_t nr);
+        void setRedPCardRight(uint8_t nr);
 
         void setUWFTimeLeft(uint8_t tens);
         void setUWFTimeRight(uint8_t tens);
@@ -104,6 +104,11 @@ class WS2812B_LedStrip : public Observer<FencingStateMachine>
         bool m_RedCardLeft = false;
         bool m_RedCardRight = false;
         uint8_t m_UW2Ftens = 0;
+        bool m_YellowPCardLeft = false;
+        bool m_YellowPCardRight = false;
+        uint8_t m_RedPCardLeft = 0;
+        uint8_t m_RedPCardRight = 0;
+
         QueueHandle_t queue = NULL;
         uint32_t m_NextTimeToTogglePrioLights;
         bool m_Animating = false;

--- a/esp32-scoring-device.ino
+++ b/esp32-scoring-device.ino
@@ -142,11 +142,13 @@ void ShowWelcomeLights()
 
   MyLedStrip.setWhiteLeft(true);
   MyLedStrip.myShow();
+  esp_task_wdt_reset();
   delay(500);// Block for 500ms.
   MyLedStrip.setWhiteLeft(false);
   MyLedStrip.myShow();
   MyLedStrip.setRed(true);
   MyLedStrip.myShow();
+  esp_task_wdt_reset();
   delay(500);// Block for 500ms.
   MyLedStrip.setRed(false);
   MyLedStrip.myShow();
@@ -158,8 +160,29 @@ void ShowWelcomeLights()
   MyLedStrip.myShow();
   MyLedStrip.setGreen(true);
   MyLedStrip.myShow();
+  esp_task_wdt_reset();
   delay(500);
   MyLedStrip.ClearAll();
+  MyLedStrip.setUWFTimeLeft(1);
+  MyLedStrip.myShow();
+  delay(500);
+  MyLedStrip.setUWFTimeLeft(2);
+  MyLedStrip.myShow();
+  delay(500);
+  MyLedStrip.setUWFTimeLeft(3);
+  MyLedStrip.myShow();
+  delay(500);
+  MyLedStrip.setUWFTimeLeft(4);
+  MyLedStrip.myShow();
+  delay(500);
+  MyLedStrip.setUWFTimeLeft(5);
+  MyLedStrip.myShow();
+  delay(500);
+  MyLedStrip.setUWFTimeLeft(6);
+  MyLedStrip.myShow();
+  delay(1000);
+  MyLedStrip.setUWFTimeLeft(0);
+  MyLedStrip.myShow();
 }
 
 void setup() {


### PR DESCRIPTION
When in direct elimination or team event, when the unwillingness to fight timer is indicated by a double blue bar at the middle columns of the Lights panels.
P-cards are shown at the opposite side of the regular cards and only 2 leds high vs. 3 for normal cards.