### PR TITLE
Fixed some Cyrano related stuff

### DIFF
--- a/FPA422Handler.cpp
+++ b/FPA422Handler.cpp
@@ -46,6 +46,12 @@ FPA422Handler::FPA422Handler()
 {
     //ctor
     //
+    Message5.SetTypeToLeft();
+    Message5.SetName("Left fencer",11);
+    Message5.SetNOC("BEL");
+    Message6.SetTypeToRight();
+    Message6.SetName("Right fencer",12);
+    Message6.SetNOC("FRA");
 }
 
 FPA422Handler::~FPA422Handler()
@@ -498,4 +504,9 @@ void FPA422Handler::update (CyranoHandler *subject, string strEFP1Message)
     Message5.SetName(EFP1Input[LeftFencerName].c_str(),EFP1Input[LeftFencerName].length());
   if(EFP1Input[LeftFencerNation] != "")
     Message5.SetNOC(EFP1Input[LeftFencerNation].c_str());
+  BTTransmitMessage(5);
+  WifiTransmitMessage(5);
+  BTTransmitMessage(6);
+  WifiTransmitMessage(6);
+
 }

--- a/FencingStateMachine.cpp
+++ b/FencingStateMachine.cpp
@@ -43,6 +43,7 @@ FencingStateMachine::FencingStateMachine(int hw_timer_nr, int tickPeriod)
     ResetAll();
     m_Timer.SetTicksPeriod(tickPeriod);
     //m_Timer.SetDisplayResolution(100);
+
 }
 
 FencingStateMachine::~FencingStateMachine()
@@ -666,6 +667,9 @@ void FencingStateMachine::DoStateMachineTick()
 #define emptystring ""
 void FencingStateMachine::ProcessDisplayMessage (const EFP1Message &input)
 {
+  m_UW2FTimer.Reset();
+  StateChanged(EVENT_UW2F_TIMER);
+
 
   if(input[Start_time] != emptystring)
   {
@@ -675,6 +679,13 @@ void FencingStateMachine::ProcessDisplayMessage (const EFP1Message &input)
   if(input[StopWatch] != emptystring)
   {
   	//Do Something with input[StopWatch];
+    uint8_t minutes = 3;
+    uint8_t seconds = 0;
+    sscanf(input[StopWatch].c_str(),"%d:%d",& minutes, & seconds);
+    m_Timer.SetMinutes(minutes);
+    m_Timer.SetSeconds(seconds);
+    m_Timer.SetHundredths(0);
+    StateChanged(MakeTimerEvent());
   }
 
   if(input[CompetitionType] != emptystring)
@@ -763,7 +774,7 @@ void FencingStateMachine::ProcessDisplayMessage (const EFP1Message &input)
   {
   	//Do Something with input[RightScore];
     sscanf(input[RightScore].c_str(),"%d",&m_ScoreRight);
-    StateChanged(EVENT_SCORE_LEFT | m_ScoreRight);
+    StateChanged(EVENT_SCORE_RIGHT | m_ScoreRight);
   }
 
   if(input[RightStatus] != emptystring)

--- a/RS422_FPA_Type5_Message.h
+++ b/RS422_FPA_Type5_Message.h
@@ -14,7 +14,7 @@ class RS422_FPA_Type5_6_Message : public RS422_FPA_Message
         RS422_FPA_Type5_6_Message& operator=(const RS422_FPA_Type5_6_Message& other);
         void SetTypeToLeft(){m_message[3]= 'L';};
         void SetTypeToRight(){m_message[3]= 'R';};
-        void SetUID(const char* name, size_t len = 20);
+        void SetUID(const char* name, size_t len = 8);
         void SetName(const char* name, size_t len = 20);
         void SetNOC(const char* NOC);
 


### PR DESCRIPTION
fpa422 type 6 package was not correctly initialized
time and score is now correctly set on DISP message
UW2F timer is reset when a new match or relay is started